### PR TITLE
Fix tag management table actions

### DIFF
--- a/frontend/src/app/content/tags/columns.tsx
+++ b/frontend/src/app/content/tags/columns.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { ColumnDef } from "@tanstack/react-table"
+import { ColumnDef, type RowData } from "@tanstack/react-table"
 import { ArrowUpDown, MoreHorizontal } from "lucide-react"
+import Link from "next/link"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -12,29 +13,32 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import Link from "next/link"
 
-// This type is used to define the shape of our data.
-// You can use a Zod schema here if you want.
 export type Tag = {
   id: number
   name: string
+}
+
+declare module "@tanstack/react-table" {
+  interface TableMeta<TData extends RowData> {
+    onDelete?: (row: TData) => void
+  }
 }
 
 export const columns: ColumnDef<Tag>[] = [
   {
     accessorKey: "id",
     header: ({ column }) => {
-        return (
-          <Button
-            variant="ghost"
-            onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-          >
-            ID
-            <ArrowUpDown className="ml-2 h-4 w-4" />
-          </Button>
-        )
-      },
+      return (
+        <Button
+          variant="ghost"
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          ID
+          <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      )
+    },
   },
   {
     accessorKey: "name",
@@ -44,6 +48,7 @@ export const columns: ColumnDef<Tag>[] = [
     id: "actions",
     cell: ({ row }) => {
       const tag = row.original
+      const handleDelete = row.table.options.meta?.onDelete
 
       return (
         <DropdownMenu>
@@ -62,13 +67,13 @@ export const columns: ColumnDef<Tag>[] = [
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem>
-                <Link href={`/content/tags/edit/${tag.id}`}>Edit</Link>
+              <Link href={`/content/tags/edit/${tag.id}`}>Edit</Link>
             </DropdownMenuItem>
             <DropdownMenuItem
-                onClick={() => (row.original as any).deleteTag(tag.id)}
-                className="text-red-500"
+              onClick={() => handleDelete?.(tag)}
+              className="text-red-500"
             >
-                Delete
+              Delete
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/src/app/content/tags/data-table.tsx
+++ b/frontend/src/app/content/tags/data-table.tsx
@@ -35,13 +35,13 @@ import { ChevronDown } from "lucide-react"
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
-  deleteCampaign: (id: number) => void; // Explicitly pass the delete handler
+  onDelete?: (row: TData) => void
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
-  deleteCampaign,
+  onDelete,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
@@ -59,9 +59,8 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     onRowSelectionChange: setRowSelection,
-    // Pass the delete function to the table meta
     meta: {
-      deleteCampaign,
+      onDelete,
     },
     state: {
       sorting,
@@ -75,7 +74,7 @@ export function DataTable<TData, TValue>({
     <div className="w-full">
       <div className="flex items-center py-4">
         <Input
-          placeholder="Filter by campaign name..."
+          placeholder="Filter by tag name..."
           value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("name")?.setFilterValue(event.target.value)

--- a/frontend/src/app/content/tags/page.tsx
+++ b/frontend/src/app/content/tags/page.tsx
@@ -1,19 +1,11 @@
-"use client";
+"use client"
 
-import { useState, useEffect } from 'react';
-import Link from 'next/link';
-import axios from 'axios';
-import { MoreHorizontal, PlusCircle } from 'lucide-react';
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import axios from "axios"
+import { PlusCircle } from "lucide-react"
 
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,109 +15,66 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { columns, Tag } from './columns';
-import { DataTable } from './data-table';
+} from "@/components/ui/alert-dialog"
+import { columns, Tag } from "./columns"
+import { DataTable } from "./data-table"
 
 const TagsPage = () => {
-  const [data, setData] = useState<Tag[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<Tag[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
 
-  // State for the delete confirmation dialog
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
-  const [itemToDelete, setItemToDelete] = useState<number | null>(null);
+  const [isAlertOpen, setIsAlertOpen] = useState(false)
+  const [itemToDelete, setItemToDelete] = useState<number | null>(null)
 
   const fetchData = async () => {
-    setLoading(true);
+    setLoading(true)
     try {
-      const response = await axios.get('/api/content/tags/');
-      setData(response.data);
+      const response = await axios.get("/api/content/tags/")
+      setData(response.data)
     } catch (err) {
-      setError('Failed to fetch tags.');
-      console.error(err);
+      setError("Failed to fetch tags.")
+      console.error(err)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   useEffect(() => {
-    fetchData();
-  }, []);
+    fetchData()
+  }, [])
 
-  // Opens the confirmation dialog
   const promptDelete = (id: number) => {
-    setItemToDelete(id);
-    setIsAlertOpen(true);
-  };
+    setItemToDelete(id)
+    setIsAlertOpen(true)
+  }
 
-  // Performs the deletion after confirmation
   const confirmDelete = async () => {
-    if (itemToDelete === null) return;
+    if (itemToDelete === null) return
 
     try {
-      await axios.delete(`/api/content/tags/${itemToDelete}/`);
-      fetchData(); // Refresh the list
+      await axios.delete(`/api/content/tags/${itemToDelete}/`)
+      fetchData()
     } catch (err) {
-      setError('Failed to delete the tag.');
-      console.error(err);
+      setError("Failed to delete the tag.")
+      console.error(err)
     } finally {
-      setIsAlertOpen(false);
-      setItemToDelete(null);
+      setIsAlertOpen(false)
+      setItemToDelete(null)
     }
-  };
-
-  const tableColumns = columns.map(col => {
-      if (col.id === 'actions') {
-          return {
-              ...col,
-              cell: ({ row }) => {
-                  const tag = row.original
-                  return (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-8 w-8 p-0">
-                          <span className="sr-only">Open menu</span>
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                        <DropdownMenuItem
-                          onClick={() => navigator.clipboard.writeText(String(tag.id))}
-                        >
-                          Copy Tag ID
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem>
-                            <Link href={`/content/tags/edit/${tag.id}`}>Edit</Link>
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                            onClick={() => promptDelete(tag.id)}
-                            className="text-red-500"
-                        >
-                            Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )
-              }
-          }
-          return col
-      }
-  )
+  }
 
   if (loading) {
-    return <div>Loading tags...</div>;
+    return <div>Loading tags...</div>
   }
 
   if (error) {
-    return <div className="text-red-500">{error}</div>;
+    return <div className="text-red-500">{error}</div>
   }
 
   return (
     <div className="container mx-auto py-10">
-      <div className="flex justify-between items-center mb-6">
+      <div className="mb-6 flex items-center justify-between">
         <h1 className="text-3xl font-bold">Manage Tags</h1>
         <Button asChild>
           <Link href="/content/tags/new">
@@ -135,13 +84,18 @@ const TagsPage = () => {
         </Button>
       </div>
 
-      <DataTable columns={tableColumns} data={data} />
+      <DataTable
+        columns={columns}
+        data={data}
+        onDelete={(tag) => promptDelete(tag.id)}
+      />
 
-      {/* Delete Confirmation Dialog */}
       <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Are you sure you want to delete this tag?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Are you sure you want to delete this tag?
+            </AlertDialogTitle>
             <AlertDialogDescription>
               This action cannot be undone. This will permanently delete the tag.
             </AlertDialogDescription>
@@ -150,14 +104,12 @@ const TagsPage = () => {
             <AlertDialogCancel onClick={() => setItemToDelete(null)}>
               Cancel
             </AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDelete}>
-              Continue
-            </AlertDialogAction>
+            <AlertDialogAction onClick={confirmDelete}>Continue</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>
-  );
-};
+  )
+}
 
-export default TagsPage;
+export default TagsPage


### PR DESCRIPTION
## Summary
- refactor the tag table columns to use table meta for delete actions instead of casting to any
- simplify the tags page and data table so the delete confirmation dialog integrates via a provided handler

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68deb487f91c832687976bd0d40eb6cb