### PR TITLE
feat: Add API documentation with Swagger and ReDoc

### DIFF
--- a/campaign_manager/settings.py
+++ b/campaign_manager/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "drf_yasg",
     "content",
     "learning",
     "github",

--- a/campaign_manager/urls.py
+++ b/campaign_manager/urls.py
@@ -17,6 +17,22 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Campaign Manager API",
+        default_version="v1",
+        description="API documentation for the Campaign Manager",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contact@campaign.local"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -24,4 +40,10 @@ urlpatterns = [
     path("api/learning/", include("learning.urls")),
     path("api/github/", include("github.urls")),
     path("api/search/", include("search.urls")),
+    path(
+        "swagger/",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
+    path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
 ]

--- a/learning/serializers.py
+++ b/learning/serializers.py
@@ -5,6 +5,7 @@ class TopicSerializer(serializers.ModelSerializer):
     class Meta:
         model = Topic
         fields = '__all__'
+        ref_name = "LearningTopic"
 
 class ChapterSerializer(serializers.ModelSerializer):
     class Meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django
 djangorestframework
 django-unfold
+drf-yasg

--- a/search/serializers.py
+++ b/search/serializers.py
@@ -9,6 +9,7 @@ class TopicSerializer(serializers.ModelSerializer):
     class Meta:
         model = Topic
         fields = '__all__'
+        ref_name = "SearchTopic"
 
 
 class TopicQuerySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This commit integrates `drf-yasg` to automatically generate API documentation for the Django backend.

- Adds `drf-yasg` to the project dependencies.
- Configures the necessary settings and URL patterns.
- Exposes two new endpoints:
  - `/swagger/`: Interactive Swagger UI for exploring and testing API endpoints.
  - `/redoc/`: Clean and readable API documentation powered by ReDoc.

It also resolves a `SwaggerGenerationError` caused by a name collision between `learning.serializers.TopicSerializer` and `search.serializers.TopicSerializer`. This is fixed by adding a unique `ref_name` to the `Meta` class of each serializer, ensuring that the OpenAPI schema can be generated correctly.